### PR TITLE
fix(seo): medium priority — self-hosted fonts, schema, security headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource-variable/manrope": "^5.2.8",
+        "@fontsource-variable/newsreader": "^5.2.10",
         "satori": "^0.26.0",
         "sharp": "^0.34.5"
       },
@@ -698,6 +701,33 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/manrope": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/manrope/-/manrope-5.2.8.tgz",
+      "integrity": "sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/newsreader": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/newsreader/-/newsreader-5.2.10.tgz",
+      "integrity": "sha512-MdI2iRwrqWpMOU/2aV2BgfZ4dJNlj/XlYaY8Zb7t87mWqHskYW0XiUANkt1cyOCiEfW2VQ0bQ5vZgGPp6B2B4w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@img/colour": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "remark-footnotes": "^4.0.1"
   },
   "dependencies": {
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/manrope": "^5.2.8",
+    "@fontsource-variable/newsreader": "^5.2.10",
     "satori": "^0.26.0",
     "sharp": "^0.34.5"
   }

--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self';object-src 'none';script-src 'self' https://asciinema.org https://static.cloudflareinsights.com 'sha256-jvrJFsPvprVcoXvfWEhqNot8KOZ1qj7RKjb5lUwfH9A=';style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;font-src 'self' https://fonts.gstatic.com;img-src 'self' https://asciinema.org data:;frame-src https://asciinema.org;report-uri https://cmolinadev.report-uri.com/r/d/csp/enforce;report-to default
+  Content-Security-Policy: default-src 'self';object-src 'none';script-src 'self' https://asciinema.org https://static.cloudflareinsights.com 'sha256-jvrJFsPvprVcoXvfWEhqNot8KOZ1qj7RKjb5lUwfH9A=';style-src 'self' 'unsafe-inline';font-src 'self';img-src 'self' https://asciinema.org data:;frame-src https://asciinema.org;report-uri https://cmolinadev.report-uri.com/r/d/csp/enforce;report-to default
   cache-control: public,max-age=300
   X-Frame-Options: SAMEORIGIN
   X-XSS-Protection: 1; mode=block

--- a/public/_headers
+++ b/public/_headers
@@ -4,6 +4,7 @@
   X-Frame-Options: SAMEORIGIN
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
   Report-To: {"group":"default","max_age":31536000,"endpoints":[{"url":"https://cmolinadev.report-uri.com/a/d/g"}],"include_subdomains":true}
   NEL: {"report_to":"default","max_age":31536000,"include_subdomains":true}
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,6 +1,6 @@
 /*
   Content-Security-Policy: default-src 'self';object-src 'none';script-src 'self' https://asciinema.org https://static.cloudflareinsights.com 'sha256-jvrJFsPvprVcoXvfWEhqNot8KOZ1qj7RKjb5lUwfH9A=';style-src 'self' 'unsafe-inline';font-src 'self';img-src 'self' https://asciinema.org data:;frame-src https://asciinema.org;report-uri https://cmolinadev.report-uri.com/r/d/csp/enforce;report-to default
-  cache-control: public,max-age=300
+  cache-control: public,max-age=3600
   X-Frame-Options: SAMEORIGIN
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,4 @@
+https://www.cmolina.dev/* https://cmolina.dev/:splat 301
 /sitemap.xml /sitemap-index.xml 301
 /posts/demistify-promises /posts/2019/08/demistify-promises 301
 /posts/images-for-every-resolution /posts/2019/07/images-for-every-resolution 301

--- a/src/components/PostsList.astro
+++ b/src/components/PostsList.astro
@@ -65,7 +65,7 @@ const { posts } = Astro.props;
   }
 
   .post-item__title {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 1.5rem;
     font-weight: 700;
     letter-spacing: -0.01em;
@@ -85,7 +85,7 @@ const { posts } = Astro.props;
   }
 
   .post-item__date {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -110,7 +110,7 @@ const { posts } = Astro.props;
     display: inline-block;
     border-bottom: 2px solid var(--secondary, #5c3cdc);
     color: var(--secondary, #5c3cdc);
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;

--- a/src/content/posts/2019/07/images-for-every-resolution.md
+++ b/src/content/posts/2019/07/images-for-every-resolution.md
@@ -2,6 +2,7 @@
 title: Using images for every resolution
 description: Learn how browsers can choose the right image for different screen resolutions
 date: 2019-07-08
+tags: [web, frontend]
 ---
 
 A couple of days ago I needed to add an icon next to a text into a website I've been working on.

--- a/src/content/posts/2019/08/demistify-promises.md
+++ b/src/content/posts/2019/08/demistify-promises.md
@@ -2,6 +2,7 @@
 title: "Know your tools: JavaScript Promises"
 description: I am sure you have used Promises before, but if you avoid them because of their mystical behavior, this article is for you.
 date: 2019-08-07
+tags: [javascript]
 ---
 
 I am sure you have used Promises before, but if you avoid them because of their mystical behavior, this article is for you.

--- a/src/content/posts/2020/01/return-early.md
+++ b/src/content/posts/2020/01/return-early.md
@@ -2,6 +2,7 @@
 title: "Small Things Matter: Returning early"
 description: Small improvements add up. Sadly, the same thing happen with less fortunate decisions. Keep your code with less indentation with this trick.
 date: 2020-01-16
+tags: [software-engineering]
 ---
 
 At the begging of my career as software developer I remember writing really long functions, full of nested conditionals.

--- a/src/content/posts/2020/02/retrying-functions.md
+++ b/src/content/posts/2020/02/retrying-functions.md
@@ -2,6 +2,7 @@
 title: "Retrying functions in JavaScript"
 description: "The problem statement is: you want to execute a function that may fail, and you want to retry it N times. How could you solve this?"
 date: 2020-02-20
+tags: [javascript]
 ---
 
 The problem statement is: you want to execute a function that may fail, and you want to retry it N times. How could you solve this?

--- a/src/content/posts/2020/05/logging-functions.md
+++ b/src/content/posts/2020/05/logging-functions.md
@@ -2,6 +2,7 @@
 title: "Logging functions in JavaScript"
 description: "Keep track of your functions and methods' inputs and outputs, cleanly."
 date: 2020-05-18
+tags: [javascript]
 ---
 
 Logs can be very useful to debug issues in production environments.

--- a/src/content/posts/2020/06/timeout-functions.md
+++ b/src/content/posts/2020/06/timeout-functions.md
@@ -2,6 +2,7 @@
 title: "Time-out functions in JavaScript"
 description: "Is it possible to stop a function if it has been running for a long time?"
 date: 2020-06-14
+tags: [javascript]
 ---
 
 I've been thinking about the problem of _time-out a function_, this is, try to run a function until a maximum amount of time, so it can either complete in time or be interrupted.

--- a/src/content/posts/2020/07/publish-typescript-package.md
+++ b/src/content/posts/2020/07/publish-typescript-package.md
@@ -2,6 +2,7 @@
 title: "Publish a TypeScript package in npm"
 description: "Write once, re-use everywhere, by publishing your code in npm!"
 date: 2020-07-11
+tags: [typescript, javascript]
 update: 2021-11-09
 ---
 

--- a/src/content/posts/2020/09/create-dark-theme.md
+++ b/src/content/posts/2020/09/create-dark-theme.md
@@ -2,6 +2,7 @@
 title: "Create a dark theme"
 description: "Learnings from adding support to dark mode to my website"
 date: 2020-09-30
+tags: [web, css]
 ---
 
 I've been interested in implementing a dark theme for my blog. I like websites that respect the user preference of using dark themes and was feeling sorry that my blog was always so bright.

--- a/src/content/posts/2021/05/migrating-from-hey.md
+++ b/src/content/posts/2021/05/migrating-from-hey.md
@@ -2,6 +2,7 @@
 title: "Migrating away from hey.com"
 description: "How to leave a product you love when you can't ignore politics"
 date: 2021-05-04
+tags: [personal]
 ---
 
 I really like the Hey email client. I am a customer since July 2020 and after onboarding, I've experienced less time managing my emails and more time doing things I love.

--- a/src/content/posts/2021/06/configure-git.md
+++ b/src/content/posts/2021/06/configure-git.md
@@ -2,6 +2,7 @@
 title: "Configuring git for the first time"
 description: "Do you have a new development laptop and you need to configure git? I got you covered"
 date: 2021-06-14
+tags: [tools, git]
 update: 2021-10-04
 ---
 

--- a/src/content/posts/2021/11/configure-terminal.md
+++ b/src/content/posts/2021/11/configure-terminal.md
@@ -2,6 +2,7 @@
 title: "My terminal configuration"
 description: "How much time do you spend in your terminal? You better be having a good time there. Learn how to customize it"
 date: 2021-11-25
+tags: [tools, terminal]
 ---
 
 Software developers can spend long periods of time in the terminal: installing dependencies, reading logs, exploring the file system and running build commands to name a few examples. For this reason, I wrote a compilation of programs that have made my life easier, by either 

--- a/src/content/posts/2023/12/faster-and-cost-effective-github-actions.md
+++ b/src/content/posts/2023/12/faster-and-cost-effective-github-actions.md
@@ -2,6 +2,7 @@
 title: "Optimizing GitHub Actions: 7 Strategies for Faster and Cost-Effective CI pipelines"
 description: "Reduce build times by dropping unnecessary steps, leveraging concurrency, caching dependencies, and smart Dependabot tricks"
 date: 2023-12-16
+tags: [ci-cd, github-actions]
 ---
 
 From time to time, I need to change my focus from working on new features to ensure build times (and build costs) are reasonable.

--- a/src/content/posts/2024/05/rock-with-acdc.md
+++ b/src/content/posts/2024/05/rock-with-acdc.md
@@ -2,6 +2,7 @@
 title: "Rock Your Code with AC/DC: Acceptance Criteria Designed Coding"
 description: "Today I am sharing a new technique I’ve been crafting for the past few years, that has allowed me to move fast in projects while maintaining high code quality"
 date: 2024-05-22
+tags: [software-engineering, testing]
 ---
 
 Welcome to the world of AC/DC, where coding meets rock 'n' roll! No, we’re not talking about shredding guitars or belting out high notes. This <abbr title="Acceptance Criteria Designed Coding">AC/DC</abbr> stands for _Acceptance Criteria Designed Coding_, a new technique I’ve been crafting for the past few years. It’s a nod to the legendary band, and a cheeky jab at [TDD](https://martinfowler.com/bliki/TestDrivenDevelopment.html) fans. Buckle up and get ready to rock your coding workflow!

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -79,10 +79,6 @@ function isActive(href: string) {
     <link rel="canonical" href={canonicalUrl} />
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <link rel="alternate" href="/feed/feed.xml" type="application/atom+xml" title={SITE_TITLE} />
-    <!-- Google Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@500&family=Manrope:wght@600;700;800&family=Newsreader:ital,opsz,wght@0,6..72,400;1,6..72,400&display=swap" rel="stylesheet" />
 <slot name="head" />
   </head>
   <body>
@@ -201,7 +197,7 @@ function isActive(href: string) {
   }
 
   .site-nav__logo {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 1.5rem;
     font-weight: 700;
     color: var(--color, #1b1c1c);
@@ -225,7 +221,7 @@ function isActive(href: string) {
   }
 
   .site-nav__link {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -259,7 +255,7 @@ function isActive(href: string) {
 
   .site-nav__cta {
     display: none;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -378,7 +374,7 @@ function isActive(href: string) {
   }
 
   .site-footer__brand .name {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 1.5rem;
     font-weight: 700;
     color: var(--color, #1b1c1c);

--- a/src/pages/about/me.astro
+++ b/src/pages/about/me.astro
@@ -121,7 +121,7 @@ import salamanderImg from '../../assets/img/about/me/salamander-frozen-2.jpg';
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 3rem;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -149,7 +149,7 @@ import salamanderImg from '../../assets/img/about/me/salamander-frozen-2.jpg';
   }
 
   .headline-xl {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: clamp(2.25rem, 5vw, 3rem);
     font-weight: 800;
     letter-spacing: -0.02em;
@@ -159,7 +159,7 @@ import salamanderImg from '../../assets/img/about/me/salamander-frozen-2.jpg';
   }
 
   .headline-lg {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 2rem;
     font-weight: 700;
     letter-spacing: -0.01em;
@@ -169,7 +169,7 @@ import salamanderImg from '../../assets/img/about/me/salamander-frozen-2.jpg';
   }
 
   .headline-md {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 1.5rem;
     font-weight: 600;
     line-height: 1.3;
@@ -193,7 +193,7 @@ import salamanderImg from '../../assets/img/about/me/salamander-frozen-2.jpg';
   .italic { font-style: italic; }
 
   .label-sm {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -249,7 +249,7 @@ import salamanderImg from '../../assets/img/about/me/salamander-frozen-2.jpg';
 
   .tag {
     padding: 0.25rem 0.75rem;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.6875rem;
     font-weight: 500;
     letter-spacing: 0.03em;
@@ -349,7 +349,7 @@ import salamanderImg from '../../assets/img/about/me/salamander-frozen-2.jpg';
     background: var(--secondary, #5c3cdc);
     border: 2px solid var(--secondary, #5c3cdc);
     color: #fff;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;

--- a/src/pages/about/me.astro
+++ b/src/pages/about/me.astro
@@ -8,9 +8,49 @@ import elephantImg from '../../assets/img/about/me/elephant.jpg';
 import llamaImg from '../../assets/img/about/me/llama.jpg';
 import rubberDuckImg from '../../assets/img/about/me/rubber-duck.jpg';
 import salamanderImg from '../../assets/img/about/me/salamander-frozen-2.jpg';
+
+const SITE_URL = 'https://cmolina.dev';
+const personId = `${SITE_URL}/#person`;
+
+const schemaGraph = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE_URL}/` },
+        { '@type': 'ListItem', position: 2, name: 'About', item: `${SITE_URL}/about/me/` },
+      ],
+    },
+    {
+      '@type': 'ProfilePage',
+      url: `${SITE_URL}/about/me/`,
+      name: 'About Me | Carlos Molina',
+      mainEntity: {
+        '@type': 'Person',
+        '@id': personId,
+        name: 'Carlos Molina',
+        alternateName: 'Carlos Andrés Molina Avendaño',
+        url: `${SITE_URL}/`,
+        image: `${SITE_URL}/og/about/me.png`,
+        jobTitle: 'Software Architect',
+        sameAs: [
+          'https://www.linkedin.com/in/carlosmolinaav/',
+          'https://github.com/cmolina',
+          'https://twitter.com/camolin3',
+        ],
+      },
+    },
+  ],
+};
 ---
 
-<Base title="About Me">
+<Base
+  title="About Me"
+  description="Meet Carlos Molina — software architect and mentor. Passionate about clarity, sustainability, and code that lasts decades."
+>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(schemaGraph)} />
+
   <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <a href="/">Home</a>

--- a/src/pages/about/services.astro
+++ b/src/pages/about/services.astro
@@ -2,9 +2,49 @@
 export const meta = { title: 'Services' };
 
 import Base from '../../layouts/Base.astro';
+
+const SITE_URL = 'https://cmolina.dev';
+const personId = `${SITE_URL}/#person`;
+const pageUrl = `${SITE_URL}/about/services/`;
+
+const schemaGraph = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE_URL}/` },
+        { '@type': 'ListItem', position: 2, name: 'Services', item: pageUrl },
+      ],
+    },
+    {
+      '@type': 'ProfessionalService',
+      '@id': `${SITE_URL}/#business`,
+      name: 'Carlos Molina — Software Architecture Consulting',
+      url: pageUrl,
+      description:
+        'I help technology organisations build resilient software systems and high-performing engineering cultures through strategic consultancy and hands-on expertise.',
+      provider: { '@id': personId },
+      hasOfferCatalog: {
+        '@type': 'OfferCatalog',
+        name: 'Services',
+        itemListElement: [
+          { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'Software Delivery Optimisation', url: pageUrl } },
+          { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'Technical Leadership Coaching', url: pageUrl } },
+          { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'Code Testing', url: pageUrl } },
+          { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'JS/TS Applications', url: pageUrl } },
+          { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'Accessibility', url: pageUrl } },
+          { '@type': 'Offer', itemOffered: { '@type': 'Service', name: 'Prototyping', url: pageUrl } },
+        ],
+      },
+    },
+  ],
+};
 ---
 
 <Base title="Services" description="I help technology organisations build resilient software systems and high-performing engineering cultures through strategic consultancy and hands-on expertise.">
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(schemaGraph)} />
+
   <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <a href="/">Home</a>

--- a/src/pages/about/services.astro
+++ b/src/pages/about/services.astro
@@ -114,7 +114,7 @@ import Base from '../../layouts/Base.astro';
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 3rem;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -136,7 +136,7 @@ import Base from '../../layouts/Base.astro';
   }
 
   .headline-xl {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: clamp(2.25rem, 5vw, 3rem);
     font-weight: 800;
     letter-spacing: -0.02em;
@@ -146,7 +146,7 @@ import Base from '../../layouts/Base.astro';
   }
 
   .headline-lg {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 2rem;
     font-weight: 700;
     letter-spacing: -0.01em;
@@ -156,7 +156,7 @@ import Base from '../../layouts/Base.astro';
   }
 
   .headline-md {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 1.5rem;
     font-weight: 600;
     line-height: 1.3;
@@ -170,7 +170,7 @@ import Base from '../../layouts/Base.astro';
 
   .label-sm {
     display: block;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -253,7 +253,7 @@ import Base from '../../layouts/Base.astro';
     background: var(--secondary, #5c3cdc);
     border: 2px solid var(--secondary, #5c3cdc);
     color: #fff;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -23,7 +23,10 @@ const posts = sortByDate(allPosts.filter(isPublished));
 
   <!-- Header -->
   <header class="page-header">
-    <h1 class="headline-xl">Notes &amp; Prototypes</h1>
+    <div class="page-header__top">
+      <h1 class="headline-xl">Notes &amp; Prototypes</h1>
+      <a href="/tags/" class="tags-link">Browse by tag →</a>
+    </div>
     <p class="body-lg muted">
       Explorations in software engineering, technical leadership, and the intersection of music
       and code. Long-form thoughts for the curious mind.
@@ -85,6 +88,30 @@ const posts = sortByDate(allPosts.filter(isPublished));
   .page-header {
     margin-bottom: 4rem;
   }
+
+  .page-header__top {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  .page-header__top .headline-xl { margin: 0; }
+
+  .tags-link {
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--secondary, #5c3cdc);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .tags-link:hover { text-decoration: underline; }
 
   .headline-xl {
     font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -66,7 +66,7 @@ const posts = sortByDate(allPosts.filter(isPublished));
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 3rem;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -87,7 +87,7 @@ const posts = sortByDate(allPosts.filter(isPublished));
   }
 
   .headline-xl {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: clamp(2.25rem, 5vw, 3rem);
     font-weight: 800;
     letter-spacing: -0.02em;
@@ -97,7 +97,7 @@ const posts = sortByDate(allPosts.filter(isPublished));
   }
 
   .headline-md {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 1.5rem;
     font-weight: 600;
     line-height: 1.3;
@@ -142,7 +142,7 @@ const posts = sortByDate(allPosts.filter(isPublished));
     border: none;
     border-bottom: 2px solid var(--outline-variant, #c4c7c7);
     padding: 0.5rem 0;
-    font-family: Newsreader, Georgia, serif;
+    font-family: 'Newsreader Variable', Newsreader, Georgia, serif;
     font-size: 1.125rem;
     color: var(--color);
     outline: none;
@@ -163,7 +163,7 @@ const posts = sortByDate(allPosts.filter(isPublished));
     padding: 0.625rem 1.5rem;
     border: 2px solid var(--color);
     color: var(--color);
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -179,7 +179,7 @@ const schemaGraph = {
 
   /* ---- Typography ---- */
   .headline-xl {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: clamp(2.25rem, 5vw, 3rem);
     font-weight: 800;
     letter-spacing: -0.02em;
@@ -189,7 +189,7 @@ const schemaGraph = {
   }
 
   .headline-md {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 1.5rem;
     font-weight: 600;
     line-height: 1.3;
@@ -214,7 +214,7 @@ const schemaGraph = {
   }
 
   .label-sm {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -229,7 +229,7 @@ const schemaGraph = {
     padding: 0.625rem 1.5rem;
     border: 2px solid var(--color);
     color: var(--color);
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -249,7 +249,7 @@ const schemaGraph = {
     background: var(--secondary, #5c3cdc);
     border: 2px solid var(--secondary, #5c3cdc);
     color: #fff;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;
@@ -270,7 +270,7 @@ const schemaGraph = {
   }
 
   .section-label {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-size: 1.25rem;
     font-weight: 700;
     letter-spacing: -0.01em;
@@ -296,7 +296,7 @@ const schemaGraph = {
   }
 
   .accent-link {
-    font-family: 'JetBrains Mono', monospace;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
     font-size: 0.8125rem;
     font-weight: 500;
     letter-spacing: 0.05em;

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -12,7 +12,36 @@ const tags = getUniqueTags(published);
 
 <Home title="Tags">
   <h1>Tags</h1>
-  {tags.map((tag) => (
-    <a href={`/tags/${tag}/`} class="post-tag">{tag}</a>
-  ))}
+  <div class="tags-list">
+    {tags.map((tag) => (
+      <a href={`/tags/${tag}/`} class="post-tag">{tag}</a>
+    ))}
+  </div>
 </Home>
+
+<style>
+  .tags-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 2rem;
+  }
+
+  .post-tag {
+    padding: 0.25rem 0.75rem;
+    font-family: 'JetBrains Mono Variable', 'JetBrains Mono', monospace;
+    font-size: 0.6875rem;
+    font-weight: 500;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    text-decoration: none;
+    background-color: var(--secondary, #5c3cdc);
+    color: #fff;
+    transition: background-color 0.2s, color 0.2s;
+  }
+
+  .post-tag:hover {
+    background-color: var(--color, #1b1c1c);
+    color: var(--surface, #fbf9f8);
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,8 @@
+@import '@fontsource-variable/newsreader/opsz.css';
+@import '@fontsource-variable/newsreader/opsz-italic.css';
+@import '@fontsource-variable/manrope';
+@import '@fontsource-variable/jetbrains-mono';
+
 :root {
     --golden-ratio: 1.618;
     --line-thickness: max(.2rem, .16em);
@@ -48,8 +53,8 @@
 }
 
 html {
-    --mono-font: 'JetBrains Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-    font-family: Newsreader, Georgia, serif;
+    --mono-font: 'JetBrains Mono Variable', 'JetBrains Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+    font-family: 'Newsreader Variable', Newsreader, Georgia, serif;
     font-weight: var(--font-weight);
     letter-spacing: var(--letter-spacing);
     line-height: 1.6;
@@ -99,7 +104,7 @@ h1, h2, h3, h4, h5, h6, a {
 }
 
 h1, h2, h3, h4, h5, h6 {
-    font-family: Manrope, system-ui, sans-serif;
+    font-family: 'Manrope Variable', Manrope, system-ui, sans-serif;
     font-weight: 700;
     letter-spacing: -0.02em;
     margin-top: 2em;

--- a/tests/e2e/tags.spec.ts
+++ b/tests/e2e/tags.spec.ts
@@ -1,8 +1,48 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('tags pages', () => {
-  test('/tags/ renders Tags heading', async ({ page }) => {
-    await page.goto('/tags/');
-    await expect(page.locator('h1')).toHaveText('Tags');
+test.describe('tags', () => {
+  test('blog index links to /tags/', async ({ page }) => {
+    await page.goto('/blog/');
+    const link = page.getByRole('link', { name: /browse by tag/i });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', '/tags/');
+  });
+
+  test.describe('/tags/', () => {
+    test('renders heading', async ({ page }) => {
+      await page.goto('/tags/');
+      await expect(page.getByRole('heading', { level: 1 })).toHaveText('Tags');
+    });
+
+    test('lists at least one tag link', async ({ page }) => {
+      await page.goto('/tags/');
+      const links = page.locator('a.post-tag');
+      await expect(links.first()).toBeVisible();
+    });
+
+    test('tag link navigates to its tag page', async ({ page }) => {
+      await page.goto('/tags/');
+      const link = page.locator('a.post-tag').first();
+      const tag = await link.textContent();
+      await link.click();
+      await expect(page).toHaveURL(new RegExp(`/tags/${tag}/`));
+      await expect(page.getByRole('heading', { level: 1 })).toContainText(tag!);
+    });
+  });
+
+  test.describe('/tags/[tag]/', () => {
+    test('shows at least one post for the tag', async ({ page }) => {
+      await page.goto('/tags/');
+      await page.locator('a.post-tag').first().click();
+      await expect(page.locator('article').first()).toBeVisible();
+    });
+
+    test('has a link back to /tags/', async ({ page }) => {
+      await page.goto('/tags/');
+      await page.locator('a.post-tag').first().click();
+      const backLink = page.getByRole('link', { name: /all tags/i });
+      await expect(backLink).toBeVisible();
+      await expect(backLink).toHaveAttribute('href', '/tags/');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Self-host fonts** via `@fontsource-variable` (Newsreader, Manrope, JetBrains Mono) — drops Google Fonts CDN dependency, eliminates render-blocking stylesheet, tightens CSP back to `self`-only for style/font sources
- **HTML cache TTL** raised from 5 min to 1 hour
- **ProfilePage + BreadcrumbList** JSON-LD added to `/about/me/` (also adds missing meta description)
- **ProfessionalService + BreadcrumbList** JSON-LD added to `/about/services/`
- **Permissions-Policy** security header added
- **`/tags/`** linked from blog index ("Browse by tag →") — page was in sitemap but had no inbound links

## Cloudflare dashboard (not in this PR)
- www 522 fix → DNS CNAME + Redirect Rule
- HSTS header → will be added in code after www is confirmed working

## Test plan
- [ ] Fonts render correctly (Newsreader body, Manrope headings, JetBrains Mono code/labels)
- [ ] `/about/me/` and `/about/services/` have correct JSON-LD (validate at search.google.com/test/rich-results)
- [ ] "Browse by tag →" link visible on `/blog/`
- [ ] Build passes: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)