### PR TITLE
feat(security): add HSTS header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,6 +5,7 @@
   X-XSS-Protection: 1; mode=block
   X-Content-Type-Options: nosniff
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Report-To: {"group":"default","max_age":31536000,"endpoints":[{"url":"https://cmolinadev.report-uri.com/a/d/g"}],"include_subdomains":true}
   NEL: {"report_to":"default","max_age":31536000,"include_subdomains":true}
 


### PR DESCRIPTION
## Summary

- Adds `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` to `public/_headers`
- Safe to enable now that `www.cmolina.dev` redirects to apex via Cloudflare Zone-level Redirect Rule

## Test plan

- [ ] Deploy and verify `Strict-Transport-Security` header is present on responses
- [ ] Submit to [HSTS preload list](https://hstspreload.org) once confirmed stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)