### PR TITLE
fix(csp+a11y): prevent font inlining and label read-more links

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -60,6 +60,11 @@ export default defineConfig({
   image: {
     domains: [],
   },
+  vite: {
+    build: {
+      assetsInlineLimit: 0,
+    },
+  },
   markdown: {
     syntaxHighlight: false,
     remarkPlugins: [remarkFootnotes],

--- a/src/components/PostsList.astro
+++ b/src/components/PostsList.astro
@@ -27,7 +27,7 @@ const { posts } = Astro.props;
         {post.data.description && (
           <p class="post-item__desc">{post.data.description}</p>
         )}
-        <a href={`/posts/${post.id}/`} class="post-item__read">
+        <a href={`/posts/${post.id}/`} class="post-item__read" aria-label={`Read full entry: ${post.data.title}`}>
           Read full entry
         </a>
       </div>


### PR DESCRIPTION
## Summary

- **CSP**: Vite was inlining small woff2 font files as base64 data URIs, violating `font-src 'self'`. Setting `assetsInlineLimit: 0` forces fonts to be emitted as separate files under `/_astro/`
- **A11y**: "Read full entry" links on the blog list now carry `aria-label="Read full entry: [post title]"` so screen readers announce each link distinctly

## Why separate font files are better

- `unicode-range` subsetting works correctly — browser only fetches the font subsets it needs
- `/_astro/*` files are served with `max-age=31536000,immutable`, so fonts are cached on repeat visits

## Why aria-label over aria-labelledby

`aria-labelledby` pointing at the `<h2>` would give the link the same accessible name as the title link above it — two identical entries in the link list. `aria-label` keeps "Read full entry: …" as a prefix, making both links distinguishable.

## Test plan

- [ ] Build and verify no `data:font/woff2` URIs appear in the output CSS
- [ ] Confirm no CSP violations in browser console on production
- [ ] Screen reader: navigate by links on `/blog` and confirm each "Read full entry" link announces its post title

🤖 Generated with [Claude Code](https://claude.com/claude-code)