### PR TITLE
feat(seo): quick-win improvements across schema, meta, and AI readiness

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,35 @@
+# Carlos Molina
+
+> Software Architecture Consultant helping companies and teams deliver software that delights, on time, by bridging the gap between technical architecture and sustainable business goals.
+
+Carlos Andrés Molina Avendaño is a Software Architect and Technical Leadership Coach based in Temuco, La Araucanía, Chile. He focuses on building software that lasts decades through clarity, documentation, and rigour — not the latest framework trend. He is currently working at [Molina Systems](https://molina.systems) providing small businesses to get online presence — from a simple landing page to a complete digital setup.
+
+## Services
+
+- [Software Delivery Optimisation](https://cmolina.dev/about/services/): Eliminating bottlenecks in development lifecycles — CI/CD pipelines, branching strategies, and deployment frequencies.
+- [Technical Leadership Coaching](https://cmolina.dev/about/services/): Coaching new Tech Leads and Engineering Managers on strategic decision-making, communication, and psychological safety.
+- [Code Testing](https://cmolina.dev/about/services/): Unit, integration, and E2E testing strategies for reliability without friction.
+- [JS/TS Applications](https://cmolina.dev/about/services/): Scalable frontends and Node services with TypeScript, designed for longevity.
+- [Accessibility](https://cmolina.dev/about/services/): WCAG compliance audits and inclusive implementation strategies.
+- [Prototyping](https://cmolina.dev/about/services/): High-fidelity functional prototypes to validate technical feasibility in days.
+
+## Blog
+
+- [Blog index](https://cmolina.dev/blog/): Technical articles on software engineering, JavaScript/TypeScript, and leadership.
+- [Rock Your Code with AC/DC: Acceptance Criteria Designed Coding](https://cmolina.dev/posts/2024/05/rock-with-acdc/): A test-driven development technique using acceptance criteria as the primary design driver.
+- [Optimizing GitHub Actions: 7 Strategies for Faster and Cost-Effective CI pipelines](https://cmolina.dev/posts/2023/12/faster-and-cost-effective-github-actions/): Practical strategies to reduce CI costs and build times.
+- [My terminal configuration](https://cmolina.dev/posts/2021/11/configure-terminal/): Developer tooling setup.
+- [Create a dark theme](https://cmolina.dev/posts/2020/09/create-dark-theme/): CSS-based dark mode implementation.
+- [Publish a TypeScript package in npm](https://cmolina.dev/posts/2020/07/publish-typescript-package/): End-to-end guide to publishing typed npm packages.
+
+## About
+
+- [About Carlos Molina](https://cmolina.dev/about/me/): Background, philosophy, and interests.
+- [Values](https://cmolina.dev/about/values/): Personal framework — Sustainable, Agile, Excellence, Stoicism.
+
+## Contact
+
+- Email: hola@cmolina.dev
+- LinkedIn: https://www.linkedin.com/in/carlosmolinaav/
+- GitHub: https://github.com/cmolina
+- RSS feed: https://cmolina.dev/feed/feed.xml

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -60,7 +60,7 @@ function isActive(href: string) {
     <meta name="theme-color" content="#fbf9f8" />
     {noindex
       ? <meta name="robots" content="noindex, nofollow" />
-      : <meta name="robots" content="max-snippet:-1, max-image-preview: large, max-video-preview: -1" />
+      : <meta name="robots" content="max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
     }
     <title>{pageTitle}</title>
     <meta property="og:title" content={pageTitle} />
@@ -146,8 +146,8 @@ function isActive(href: string) {
         </div>
         <ul class="site-footer__links">
           <li><a href="mailto:hola@cmolina.dev">Email</a></li>
-          <li><a href="https://www.linkedin.com/in/carlosmolinaav/" target="_blank" rel="noopener">LinkedIn</a></li>
-          <li><a href="https://github.com/cmolina" target="_blank" rel="noopener">GitHub</a></li>
+          <li><a href="https://www.linkedin.com/in/carlosmolinaav/" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+          <li><a href="https://github.com/cmolina" target="_blank" rel="noopener noreferrer">GitHub</a></li>
           <li><a href="/feed/feed.xml">RSS</a></li>
         </ul>
       </div>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -15,6 +15,7 @@ interface Props {
 }
 
 const SITE_URL = 'https://cmolina.dev';
+const personId = `${SITE_URL}/#person`;
 
 const { title, description, date, update, slug, body, prevPost, nextPost } = Astro.props;
 
@@ -24,15 +25,15 @@ const pageUrl = `/posts/${slug}/`;
 const shareUrl = `${SITE_URL}${pageUrl}`;
 const ogImage = `${SITE_URL}/og/${slug}.png`;
 
-const author = { '@type': 'Person', name: 'Carlos Molina', url: `${SITE_URL}/` };
+const personRef = { '@id': personId };
 
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'BlogPosting',
   headline: title,
   image: [ogImage],
-  author,
-  publisher: author,
+  author: personRef,
+  publisher: personRef,
   url: shareUrl,
   mainEntityOfPage: shareUrl,
   datePublished: htmlDateString(date),

--- a/src/pages/about/values.astro
+++ b/src/pages/about/values.astro
@@ -2,9 +2,38 @@
 export const meta = { title: 'My Values' };
 
 import Base from '../../layouts/Base.astro';
+
+const SITE_URL = 'https://cmolina.dev';
+const personId = `${SITE_URL}/#person`;
+const pageUrl = `${SITE_URL}/about/values/`;
+
+const schemaGraph = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE_URL}/` },
+        { '@type': 'ListItem', position: 2, name: 'Values', item: pageUrl },
+      ],
+    },
+    {
+      '@type': 'WebPage',
+      url: pageUrl,
+      name: 'My Values | Carlos Molina',
+      description: 'A personal framework of four pillars — Sustainable, Agile, Excellence, and Stoicism — that guides my decisions in software, work, and life.',
+      author: { '@id': personId },
+      inLanguage: 'en',
+    },
+  ],
+};
 ---
 
-<Base title="My Values">
+<Base
+  title="My Values"
+  description="A personal framework of four pillars — Sustainable, Agile, Excellence, and Stoicism — that guides my decisions in software, work, and life."
+>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(schemaGraph)} />
   <h1>My Values</h1>
   <p>Every day we make decisions. Some of these problems are either trivial, there is already a known solution, or picking any option doesn't have a huge impact. For more complex scenarios, it is useful to have a framework to guide you to the best solution.</p>
 

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -9,11 +9,44 @@ import { isPublished, sortByDate } from '../../utils/posts';
 import Base from '../../layouts/Base.astro';
 import PostsList from '../../components/PostsList.astro';
 
+const SITE_URL = 'https://cmolina.dev';
+const personId = `${SITE_URL}/#person`;
+
 const allPosts = await getCollection('posts');
 const posts = sortByDate(allPosts.filter(isPublished));
+
+const schemaGraph = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: `${SITE_URL}/` },
+        { '@type': 'ListItem', position: 2, name: 'Blog', item: `${SITE_URL}/blog/` },
+      ],
+    },
+    {
+      '@type': 'Blog',
+      '@id': `${SITE_URL}/blog/`,
+      name: 'Carlos Molina — Blog',
+      url: `${SITE_URL}/blog/`,
+      description: meta.description,
+      author: { '@id': personId },
+      inLanguage: 'en',
+      blogPost: posts.map((p) => ({
+        '@type': 'BlogPosting',
+        headline: p.data.title,
+        url: `${SITE_URL}/posts/${p.id}/`,
+        datePublished: p.data.date.toISOString().split('T')[0],
+        author: { '@id': personId },
+      })),
+    },
+  ],
+};
 ---
 
 <Base title="Blog" description={meta.description}>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(schemaGraph)} />
   <!-- Breadcrumbs -->
   <nav class="breadcrumbs" aria-label="Breadcrumb">
     <a href="/">Home</a>
@@ -24,7 +57,7 @@ const posts = sortByDate(allPosts.filter(isPublished));
   <!-- Header -->
   <header class="page-header">
     <div class="page-header__top">
-      <h1 class="headline-xl">Notes &amp; Prototypes</h1>
+      <h1 class="headline-xl">Blog</h1>
       <a href="/tags/" class="tags-link">Browse by tag →</a>
     </div>
     <p class="body-lg muted">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -45,7 +45,7 @@ const schemaGraph = {
 };
 ---
 
-<Base description="I help companies and teams deliver software that delights, on time, by bridging the gap between technical architecture and sustainable business goals.">
+<Base title="Software Architecture Consultant" description="I help companies and teams deliver software that delights, on time, by bridging the gap between technical architecture and sustainable business goals.">
   <script slot="head" type="application/ld+json" set:html={JSON.stringify(schemaGraph)} />
   <!-- Hero -->
   <section class="hero">


### PR DESCRIPTION
## Summary

- Homepage `<title>` now includes role keyword → **Software Architecture Consultant | Carlos Molina**
- Blog H1 changed from "Notes & Prototypes" → **Blog** for keyword alignment
- Blog index (`/blog/`) gets `BreadcrumbList` + `Blog` schema with all posts listed as `BlogPosting` items
- Values page (`/about/values/`) gets meta description + `BreadcrumbList` + `WebPage` schema
- `BlogPosting` author/publisher now reference the site-wide `Person @id` instead of duplicate inline objects
- Footer external links upgraded from `rel="noopener"` → `rel="noopener noreferrer"`
- Fixed space in robots meta directive (`max-image-preview:large`)
- Added `public/llms.txt` for AI search engine citability (Perplexity, ChatGPT Browse, Bing Copilot)

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Homepage title renders as "Software Architecture Consultant | Carlos Molina"
- [ ] `/blog/` H1 shows "Blog" and JSON-LD schema is present in `<head>`
- [ ] `/about/values/` has meta description and JSON-LD in `<head>`
- [ ] Blog post JSON-LD: `author` and `publisher` both have `@id` only, no inline Person objects
- [ ] `https://cmolina.dev/llms.txt` is served after deploy
- [ ] Validate schemas at https://validator.schema.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)